### PR TITLE
Remove Redundant Import Statement

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 
-	etcdCtx "github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
 )
@@ -44,14 +43,14 @@ type EtcdWrapper struct {
 }
 
 func (e *EtcdWrapper) Get(ctx context.Context, key string, opts *client.GetOptions) (*client.Response, error) {
-	return e.Etcd.Get(ctx.(etcdCtx.Context), key, opts)
+	return e.Etcd.Get(ctx.(context.Context), key, opts)
 }
 func (e *EtcdWrapper) Set(ctx context.Context, key, value string, opts *client.SetOptions) (*client.Response, error) {
-	return e.Etcd.Set(ctx.(etcdCtx.Context), key, value, opts)
+	return e.Etcd.Set(ctx.(context.Context), key, value, opts)
 }
 
 func (e *EtcdWrapper) Create(ctx context.Context, key, value string) (*client.Response, error) {
-	return e.Etcd.Create(ctx.(etcdCtx.Context), key, value)
+	return e.Etcd.Create(ctx.(context.Context), key, value)
 }
 
 func NewEtcdWrapper(etcd client.KeysAPI) *EtcdWrapper {


### PR DESCRIPTION
Removal of import  statement (redundant) would break immediately if an upstream package is using
vendoring and stripping sub-vendor directories or "flattening".  See
https://github.com/Masterminds/glide/issues/303 for more.

* Remove redundant import statement